### PR TITLE
fix: EventBridgesExtension $bridgeConfig null handling

### DIFF
--- a/src/DI/EventBridgesExtension.php
+++ b/src/DI/EventBridgesExtension.php
@@ -47,7 +47,6 @@ class EventBridgesExtension extends CompilerExtension
 			// Register sub extension a.k.a CompilerPass
 			$this->passes[$bridge] = new $this->map[$bridge]();
 			$this->passes[$bridge]->setCompiler($this->compiler, $this->prefix($bridge));
-			$this->passes[$bridge]->setConfig($bridgeConfig);
 
 			if ($bridgeConfig !== null) {
 				$this->passes[$bridge]->setConfig($bridgeConfig);


### PR DESCRIPTION
I believe that added code in commit below should replace the row above it.
When $bridgeConfig is null Nette throws Nette\InvalidArgumentException.

https://github.com/contributte/event-dispatcher-extra/commit/9417598b7d24d662ec6e0d0a0e6790592ca23002